### PR TITLE
Add support for events 'payment_succeeded' and 'payment_refunded'

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,12 @@ const paddleSdk = new PaddleSdk<PaddleMetadata>({
 If you are using `parseWebhookEvent` on raw events, only enable the following events in your
 dashboard to prevent `ImplementationMissing` errors being thrown.
 
-- Subscription Created
-- Subscription Updated
-- Subscription Cancelled
-- Subscription Payment Success
+- [Payment Succeeded](https://developer.paddle.com/webhook-reference/one-off-purchase-alerts/payment-succeeded)
+- [Payment Refunded](https://developer.paddle.com/webhook-reference/one-off-purchase-alerts/payment-refunded)
+- [Subscription Created](https://developer.paddle.com/webhook-reference/subscription-alerts/subscription-created)
+- [Subscription Updated](https://developer.paddle.com/webhook-reference/subscription-alerts/subscription-updated)
+- [Subscription Cancelled](https://developer.paddle.com/webhook-reference/subscription-alerts/subscription-cancelled)
+- [Subscription Payment Succeeded](https://developer.paddle.com/webhook-reference/subscription-alerts/subscription-payment-succeeded)
 
 ## Contributors
 

--- a/src/helpers/converters.ts
+++ b/src/helpers/converters.ts
@@ -2,6 +2,7 @@ import {
   RawPaddleSubscriptionCreatedAlert,
   RawPaddleSubscriptionUpdatedAlert,
   RawPaddleSubscriptionPaymentSucceededAlert,
+  RawPaddlePaymentRefundedAlert,
 } from '../__generated__/webhook-alerts'
 import {
   PaddleSdkSubscriptionStatus,
@@ -10,6 +11,7 @@ import {
   PaddleSdkCurrency,
   PaddleSdkCountry,
   PaddleSdkCardBrand,
+  PaddleSdkRefundType,
 } from '../interfaces'
 import dayjs from 'dayjs'
 import customParseFormat from 'dayjs/plugin/customParseFormat'
@@ -153,6 +155,19 @@ export function convertApiCardBrand(cardBrand: string): PaddleSdkCardBrand {
   }
 
   return PaddleSdkCardBrand.UNKNOWN
+}
+
+export function convertApiRefundType(
+  refundType: RawPaddlePaymentRefundedAlert['refund_type']
+): PaddleSdkRefundType {
+  switch (refundType) {
+    case 'full':
+      return PaddleSdkRefundType.FULL
+    case 'vat':
+      return PaddleSdkRefundType.VAT
+    case 'partial':
+      return PaddleSdkRefundType.PARTIAL
+  }
 }
 
 export function convertSdkPriceList(

--- a/src/helpers/converters.ts
+++ b/src/helpers/converters.ts
@@ -26,8 +26,8 @@ export function convertApiFloat(floatString: string): number {
   return parseFloat(floatString)
 }
 
-export function convertApiBoolean(booleanString: '0' | '1'): boolean {
-  return booleanString === '1'
+export function convertApiBoolean(booleanString: '0' | '1' | 'false' | 'true'): boolean {
+  return booleanString === '1' || booleanString === 'true'
 }
 
 export function convertSdkBoolean(boolean: boolean): 0 | 1 {

--- a/src/index.ts
+++ b/src/index.ts
@@ -176,7 +176,7 @@ export class PaddleSdk<TMetadata = any> {
       checkoutId: body.checkout_id,
       coupon: body.coupon,
       receiptUrl: body.receipt_url,
-      productId: body.product_id,
+      productId: convertApiInteger(body.product_id),
       productName: body.product_name,
       quantity: convertApiInteger(body.quantity),
       paymentMethod: convertApiPaymentMethod(body.payment_method),

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,6 +1,6 @@
 import {
-  RawPaddleEnumCurrencies as PaddleSdkCurrency,
   RawPaddleEnumCountries as PaddleSdkCountry,
+  RawPaddleEnumCurrencies as PaddleSdkCurrency,
 } from './__generated__/enums'
 
 // ----------------------------------------------------------------------------
@@ -9,6 +9,8 @@ import {
 
 /** A type of a webhook event */
 export enum PaddleSdkWebhookEventType {
+  'PAYMENT_SUCCEEDED' = 'PAYMENT_SUCCEEDED',
+  'PAYMENT_REFUNDED' = 'PAYMENT_REFUNDED',
   'SUBSCRIPTION_CREATED' = 'SUBSCRIPTION_CREATED',
   'SUBSCRIPTION_UPDATED' = 'SUBSCRIPTION_UPDATED',
   'SUBSCRIPTION_CANCELLED' = 'SUBSCRIPTION_CANCELLED',
@@ -81,6 +83,175 @@ export enum PaddleSdkRefundType {
 // ----------------------------------------------------------------------------
 // WEBHOOKS
 // ----------------------------------------------------------------------------
+
+/** An event fired when a one-off purchase payment is made */
+export type PaddleSdkPaymentSucceededEvent<TMetadata> = {
+  // EVENT ---
+
+  /** The type of this event */
+  eventType: PaddleSdkWebhookEventType.PAYMENT_SUCCEEDED
+
+  /** The unique ID for this event */
+  eventId: number
+
+  /** The date and time the event was fired */
+  eventTime: Date
+
+  // ORDER ---
+
+  /** The value passed into the pay link / set via the API using the `metadata` parameter */
+  metadata: TMetadata
+
+  /** The unique order ID for this payment */
+  orderId: string
+
+  /** The unique checkout ID of the order */
+  checkoutId: string
+
+  /** The coupon code used on this order */
+  coupon: string
+
+  /** The URL containing the customer receipt for this order */
+  receiptUrl: string
+
+  /** The dashboard ID of the product purchased in this order */
+  productId: string
+
+  /** The name of the product included in the order */
+  productName: string
+
+  /** The number of products or in this order */
+  quantity: number
+
+  /** The payment method used to make the transaction */
+  paymentMethod: PaddleSdkPaymentMethod
+
+  /** The currency of the order */
+  currency: PaddleSdkCurrency
+
+  /** The total amount the customer was charged for this payment */
+  gross: number
+
+  /** The amount of tax paid for this payment */
+  tax: number
+
+  /** The amount of fees paid for this payment */
+  fee: number
+
+  /** The total amount (after taxes and fees) earned from this payment */
+  earnings: number
+
+  /** Whether the dashboard price was overridden */
+  usedPriceOverride: boolean
+
+  // CUSTOMER ---
+
+  /** The name of the customer */
+  customerName: string
+
+  /** The email address of the customer */
+  customerEmail: string
+
+  /** The country of the customer */
+  customerCountry: PaddleSdkCountry
+
+  /** Whether the customer has agreed to receive marketing messages */
+  hasMarketingConsent: boolean
+
+  // BALANCE ---
+
+  /** The currency of the vendor */
+  balanceCurrency: PaddleSdkCurrency
+
+  /** The total amount received from the customer (in the vendor's currency) */
+  balanceGross: number
+
+  /** The amount of tax received from the customer (in the vendor's currency) */
+  balanceTax: number
+
+  /** The amount of fees taken from the vendor (in the vendor's currency) */
+  balanceFee: number
+
+  /** The amount earned from this payment (in the vendor's currency) */
+  balanceEarnings: number
+}
+
+/** An event fired when a one-off purchase payment is refunded */
+export type PaddleSdkPaymentRefundedEvent<TMetadata> = {
+  // EVENT ---
+
+  /** The type of this event */
+  eventType: PaddleSdkWebhookEventType.PAYMENT_REFUNDED
+
+  /** The unique ID for this event */
+  eventId: number
+
+  /** The date and time the event was fired */
+  eventTime: Date
+
+  // ORDER ---
+
+  /** The value passed into the pay link / set via the API using the `metadata` parameter */
+  metadata: TMetadata
+
+  /** The unique order ID for this payment */
+  orderId: string
+
+  /** The unique checkout ID of the order */
+  checkoutId: string
+
+  /** The type of refund */
+  refundType: PaddleSdkRefundType
+
+  /** Refund reason note */
+  refundReason: string
+
+  /** The number of products or subscription seats sold in the transaction */
+  quantity: number
+
+  /** The currency of the order */
+  currency: PaddleSdkCurrency
+
+  /** The amount refunded, partial refunds are possible */
+  amount: number
+
+  /** The amount of tax returned to the customer, in the currency of the original transaction */
+  taxRefund: number
+
+  /** The fee amount returned to the vendor, in the currency of the original transaction */
+  feeRefund: number
+
+  /** The total amount returned to the customer as a result of this refund, in the currency of the original transaction */
+  grossRefund: number
+
+  /** The amount of revenue taken from the vendor’s earnings as a result of this refund, in the currency of the original transaction */
+  earningsDecrease: number
+
+  // CUSTOMER ---
+
+  /** The email address of the customer */
+  customerEmail: string
+
+  /** Whether the customer has agreed to receive marketing messages */
+  hasMarketingConsent: boolean
+
+  // BALANCE ---
+
+  /** The currency of the vendor */
+  balanceCurrency: PaddleSdkCurrency
+
+  /** The total amount returned to the customer as a result of this refund, in the vendor’s default currency at the time of the transaction */
+  balanceGrossRefund: number
+
+  /** The amount of tax returned to the customer, in the vendor’s default currency at the time of the transaction */
+  balanceTaxRefund: number
+
+  /** The fee amount returned to the vendor, in the vendor’s default currency at the time of the transaction */
+  balanceFeeRefund: number
+
+  /** The amount of revenue taken from the vendor’s earnings as a result of this refund, in the vendor’s default currency at the time of the transaction */
+  balanceEarningsDecrease: number
+}
 
 /** An event fired when a subscription is created */
 export type PaddleSdkSubscriptionCreatedEvent<TMetadata> = {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -71,6 +71,13 @@ export enum PaddleSdkCardBrand {
   'UNKNOWN' = 'UNKNOWN',
 }
 
+/** Refund type */
+export enum PaddleSdkRefundType {
+  'FULL' = 'FULL',
+  'VAT' = 'VAT',
+  'PARTIAL' = 'PARTIAL',
+}
+
 // ----------------------------------------------------------------------------
 // WEBHOOKS
 // ----------------------------------------------------------------------------

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -115,7 +115,7 @@ export type PaddleSdkPaymentSucceededEvent<TMetadata> = {
   receiptUrl: string
 
   /** The dashboard ID of the product purchased in this order */
-  productId: string
+  productId: number
 
   /** The name of the product included in the order */
   productName: string

--- a/tests/__snapshots__/parse-webhook-event.spec.ts.snap
+++ b/tests/__snapshots__/parse-webhook-event.spec.ts.snap
@@ -4,6 +4,69 @@ exports[`parse webhook event errors if the metadata can not be parsed 1`] = `"Fa
 
 exports[`parse webhook event errors if the webhook signature can not be validated 1`] = `"Failed validating webhook event body"`;
 
+exports[`parse webhook event parses a "payment refunded" event correctly 1`] = `
+Object {
+  "amount": 414.43,
+  "balanceCurrency": "USD",
+  "balanceEarningsDecrease": 0.34,
+  "balanceFeeRefund": 0.11,
+  "balanceGrossRefund": 0.28,
+  "balanceTaxRefund": 0.96,
+  "checkoutId": "9-a568055ec8edc7b-e57313c2c0",
+  "currency": "EUR",
+  "customerEmail": "foo@bar.com",
+  "earningsDecrease": 0.08,
+  "eventId": 123456789,
+  "eventTime": 2020-08-12T21:01:30.000Z,
+  "eventType": "PAYMENT_REFUNDED",
+  "feeRefund": 0.86,
+  "grossRefund": 0.61,
+  "hasMarketingConsent": true,
+  "metadata": Object {
+    "foo": "bar",
+  },
+  "orderId": "8",
+  "quantity": 68,
+  "refundReason": "Example Reason",
+  "refundType": "FULL",
+  "taxRefund": 0.76,
+}
+`;
+
+exports[`parse webhook event parses a "payment succeeded" event correctly 1`] = `
+Object {
+  "balanceCurrency": "USD",
+  "balanceEarnings": 317.23,
+  "balanceFee": 875.73,
+  "balanceGross": 800.96,
+  "balanceTax": 412.02,
+  "checkoutId": "9-656d6c95693cd5b-77ea2a55f9",
+  "coupon": "Coupon 9",
+  "currency": "EUR",
+  "customerCountry": "AU",
+  "customerEmail": "foo@bar.com",
+  "customerName": "Customer Name",
+  "earnings": 140.26,
+  "eventId": 123456789,
+  "eventTime": 2020-08-12T21:01:30.000Z,
+  "eventType": "PAYMENT_SUCCEEDED",
+  "fee": 0.75,
+  "gross": 804.76,
+  "hasMarketingConsent": true,
+  "metadata": Object {
+    "foo": "bar",
+  },
+  "orderId": "3",
+  "paymentMethod": "PAYPAL",
+  "productId": "4",
+  "productName": "Example Product Name",
+  "quantity": 77,
+  "receiptUrl": "https://my.paddle.com/receipt/5/2fe1b313345427e-2e6b05993f",
+  "tax": 0.48,
+  "usedPriceOverride": true,
+}
+`;
+
 exports[`parse webhook event parses a "subscription cancelled" event correctly 1`] = `
 Object {
   "cancelledFrom": 2020-08-12T00:00:00.000Z,

--- a/tests/__snapshots__/parse-webhook-event.spec.ts.snap
+++ b/tests/__snapshots__/parse-webhook-event.spec.ts.snap
@@ -58,7 +58,7 @@ Object {
   },
   "orderId": "3",
   "paymentMethod": "PAYPAL",
-  "productId": "4",
+  "productId": 4,
   "productName": "Example Product Name",
   "quantity": 77,
   "receiptUrl": "https://my.paddle.com/receipt/5/2fe1b313345427e-2e6b05993f",

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -1,15 +1,17 @@
 import {
   RawPaddlePostProductGeneratePayLinkResponse,
+  RawPaddlePostSubscriptionModifiersCreateResponse,
+  RawPaddlePostSubscriptionUsersCancelResponse,
   RawPaddlePostSubscriptionUsersResponse,
   RawPaddlePostSubscriptionUsersUpdateResponse,
-  RawPaddlePostSubscriptionUsersCancelResponse,
-  RawPaddlePostSubscriptionModifiersCreateResponse,
 } from '../src/__generated__/api-routes'
 import {
-  RawPaddleSubscriptionCreatedAlert,
-  RawPaddleSubscriptionUpdatedAlert,
+  RawPaddlePaymentRefundedAlert,
+  RawPaddlePaymentSucceededAlert,
   RawPaddleSubscriptionCancelledAlert,
+  RawPaddleSubscriptionCreatedAlert,
   RawPaddleSubscriptionPaymentSucceededAlert,
+  RawPaddleSubscriptionUpdatedAlert,
 } from '../src/__generated__/webhook-alerts'
 
 export const publicKey = `-----BEGIN PUBLIC KEY-----
@@ -32,6 +34,64 @@ export const vendorId = 123456
 export const vendorAuthCode = 'FooBarBaz'
 
 export const metadataEncryptionKey = 'ZtdDl3Ex7ycFfgdbAC3uTLNk8eLVDcEd'
+
+export const paymentSucceededEvent: RawPaddlePaymentSucceededAlert = {
+  alert_id: `123456789`,
+  alert_name: `payment_succeeded`,
+  balance_currency: `USD`,
+  balance_earnings: `317.23`,
+  balance_fee: `875.73`,
+  balance_gross: `800.96`,
+  balance_tax: `412.02`,
+  checkout_id: `9-656d6c95693cd5b-77ea2a55f9`,
+  country: `AU`,
+  coupon: `Coupon 9`,
+  currency: `EUR`,
+  customer_name: `Customer Name`,
+  earnings: `140.26`,
+  email: `foo@bar.com`,
+  event_time: `2020-08-12 21:01:30`,
+  fee: `0.75`,
+  ip: `89.207.217.18`,
+  marketing_consent: `1`,
+  order_id: `3`,
+  p_signature: `GLv7wxZi4E1GLo+SmFnq3OAiZ7ib8wcU/WBh/8sXlmocTIBBx5yBjnvDbE0qaNgxMlew/esYfDv1ApHAnz93J/MziloBoLmu/8YCjDddVFs1R/Y+2sbIhkI5xu84Uz1BobkIPtR/+GVgI0k2XeLudG3weCc6/eUa/T3dxc0p9b9aenKGig1HxHpWTCBi5fnr121c7HDlly6eyPlGrmk5yrwtbfTGBmvrwU3c3X7Nh0lVGEMt1Y2KEqgfFsaGwdg9JnT/xDg33NyEKDPOu0asvb6cPmRS+q+ojUnzBldFCd/+/H9TjE/Qjoqy8bNNjAIKH3kReyZls42631Hf3DuqsTLg2uR6xQCXTxLvRukdkUKsidu2sadLJ5NgibpnWsplgptS7AFXwm7uwvarFmbwSrN1YgI3vvN/Hm3/3xWHlpbfhUKDeOu2O5JW8drsgFNY2DIdE57HqseutKypp0shgZBfDn+aYyk6o0GhbmkY54dmtFRqxCFNFiy5TXfKQcFKi71nvYdd6ILQOj43HKvNScKm4cuiCqoLNOtYs3kY1k8nlvgyTY6EV1vYf+I84bt/BbKDgwNTmJoHwAeRACwVg59wb1hV5upCbHFy/Qn3/M189Nl6FiutlGqnuTwEwxapdGbFegjAd062OA8Ye4yixIOnsPIWGsTGcIkHEQyRLN0=`,
+  passthrough: `kLFV0ZkzYdTrYKIvFhQlkK9vccfQP0FxGpK10j563YK2zCGdhMij2aX/sblM`,
+  payment_method: `paypal`,
+  payment_tax: `0.48`,
+  product_id: `4`,
+  product_name: `Example Product Name`,
+  quantity: `77`,
+  receipt_url: `https://my.paddle.com/receipt/5/2fe1b313345427e-2e6b05993f`,
+  sale_gross: `804.76`,
+  used_price_override: `true`,
+}
+
+export const paymentRefundedEvent: RawPaddlePaymentRefundedAlert = {
+  alert_id: `123456789`,
+  alert_name: 'payment_refunded',
+  amount: `414.43`,
+  balance_currency: `USD`,
+  balance_earnings_decrease: `0.34`,
+  balance_fee_refund: `0.11`,
+  balance_gross_refund: `0.28`,
+  balance_tax_refund: `0.96`,
+  checkout_id: `9-a568055ec8edc7b-e57313c2c0`,
+  currency: `EUR`,
+  earnings_decrease: `0.08`,
+  email: `foo@bar.com`,
+  event_time: `2020-08-12 21:01:30`,
+  fee_refund: `0.86`,
+  gross_refund: `0.61`,
+  marketing_consent: `1`,
+  order_id: `8`,
+  p_signature: `GLv7wxZi4E1GLo+SmFnq3OAiZ7ib8wcU/WBh/8sXlmocTIBBx5yBjnvDbE0qaNgxMlew/esYfDv1ApHAnz93J/MziloBoLmu/8YCjDddVFs1R/Y+2sbIhkI5xu84Uz1BobkIPtR/+GVgI0k2XeLudG3weCc6/eUa/T3dxc0p9b9aenKGig1HxHpWTCBi5fnr121c7HDlly6eyPlGrmk5yrwtbfTGBmvrwU3c3X7Nh0lVGEMt1Y2KEqgfFsaGwdg9JnT/xDg33NyEKDPOu0asvb6cPmRS+q+ojUnzBldFCd/+/H9TjE/Qjoqy8bNNjAIKH3kReyZls42631Hf3DuqsTLg2uR6xQCXTxLvRukdkUKsidu2sadLJ5NgibpnWsplgptS7AFXwm7uwvarFmbwSrN1YgI3vvN/Hm3/3xWHlpbfhUKDeOu2O5JW8drsgFNY2DIdE57HqseutKypp0shgZBfDn+aYyk6o0GhbmkY54dmtFRqxCFNFiy5TXfKQcFKi71nvYdd6ILQOj43HKvNScKm4cuiCqoLNOtYs3kY1k8nlvgyTY6EV1vYf+I84bt/BbKDgwNTmJoHwAeRACwVg59wb1hV5upCbHFy/Qn3/M189Nl6FiutlGqnuTwEwxapdGbFegjAd062OA8Ye4yixIOnsPIWGsTGcIkHEQyRLN0=`,
+  passthrough: `kLFV0ZkzYdTrYKIvFhQlkK9vccfQP0FxGpK10j563YK2zCGdhMij2aX/sblM`,
+  quantity: `68`,
+  refund_reason: `Example Reason`,
+  refund_type: `full`,
+  tax_refund: `0.76`,
+}
 
 export const subscriptionCreatedEvent: RawPaddleSubscriptionCreatedAlert = {
   alert_id: `2091557455`,

--- a/tests/helpers/converters.spec.ts
+++ b/tests/helpers/converters.spec.ts
@@ -113,6 +113,12 @@ describe('helpers -> converters', () => {
     expect(converters.convertApiCardBrand('xxx')).toEqual('UNKNOWN')
   })
 
+  it('can convert an refund type', () => {
+    expect(converters.convertApiRefundType('full')).toEqual('FULL')
+    expect(converters.convertApiRefundType('vat')).toEqual('VAT')
+    expect(converters.convertApiRefundType('partial')).toEqual('PARTIAL')
+  })
+
   it('can convert an SDK price list', () => {
     expect(
       converters.convertSdkPriceList([

--- a/tests/helpers/converters.spec.ts
+++ b/tests/helpers/converters.spec.ts
@@ -14,6 +14,8 @@ describe('helpers -> converters', () => {
   it('can convert an API boolean', () => {
     expect(converters.convertApiBoolean('1')).toEqual(true)
     expect(converters.convertApiBoolean('0')).toEqual(false)
+    expect(converters.convertApiBoolean('true')).toEqual(true)
+    expect(converters.convertApiBoolean('false')).toEqual(false)
   })
 
   it('can convert an SDK boolean', () => {

--- a/tests/parse-webhook-event.spec.ts
+++ b/tests/parse-webhook-event.spec.ts
@@ -11,6 +11,14 @@ const paddleSdk = new PaddleSdk({
 ;(paddleSdk as any).verifyWebhookEvent = () => true
 
 describe('parse webhook event', () => {
+  it('parses a "payment succeeded" event correctly', () => {
+    expect(paddleSdk.parseWebhookEvent(FIXTURES.paymentSucceededEvent)).toMatchSnapshot()
+  })
+
+  it('parses a "payment refunded" event correctly', () => {
+    expect(paddleSdk.parseWebhookEvent(FIXTURES.paymentRefundedEvent)).toMatchSnapshot()
+  })
+
   it('parses a "subscription created" event correctly', () => {
     expect(paddleSdk.parseWebhookEvent(FIXTURES.subscriptionCreatedEvent)).toMatchSnapshot()
   })


### PR DESCRIPTION
This PR adds interfaces, parsers and tests to support more event types such as 'payment_succeeded' and 'payment_refunded'